### PR TITLE
Feature/configurable file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- [Configurable file permissions #51](https://github.com/xmidt-org/sallust/issues/51)
+
 ## [v0.2.1]
 - [Pruned deprecated code #43](https://github.com/xmidt-org/sallust/pull/43)
 

--- a/config.go
+++ b/config.go
@@ -26,6 +26,12 @@ const (
 	// DefaultNameKey is the default value for EncoderConfig.NameKey.  This value
 	// is not used if EncoderConfig.DisableDefaultKeys is true.
 	DefaultNameKey = "name"
+
+	// Stdout is the reserved zap output path name that corresponds to stdout.
+	Stdout = "stdout"
+
+	// Stderr is the reserved zap output path name that corresponds to stderr.
+	Stderr = "stderr"
 )
 
 // EncoderConfig is an analog to zap.EncoderConfig.  This type is friendlier
@@ -253,7 +259,7 @@ type Config struct {
 	OutputPaths []string `json:"outputPaths" yaml:"outputPaths"`
 
 	// ErrorOutputPaths are the set of sinks for zap's internal messages.  This field
-	// corresponds to zap.Config.ErrorOutputPaths.  If unset, "stderr" is assumed.
+	// corresponds to zap.Config.ErrorOutputPaths.  If unset, Stderr is assumed.
 	//
 	// As with OutputPaths, environment variable references in each path are expanded
 	// unless DisablePathExpansion is true.
@@ -294,11 +300,11 @@ func applyConfigDefaults(zc *zap.Config) {
 
 	if zc.Development && len(zc.OutputPaths) == 0 {
 		// NOTE: difference from zap ... in development they send output to stderr
-		zc.OutputPaths = []string{"stdout"}
+		zc.OutputPaths = []string{Stdout}
 	}
 
 	if len(zc.ErrorOutputPaths) == 0 {
-		zc.ErrorOutputPaths = []string{"stderr"}
+		zc.ErrorOutputPaths = []string{Stderr}
 	}
 
 	// NOTE: can't compare the Level with nil very easily, so just
@@ -324,10 +330,10 @@ func ensureExists(path string, perms fs.FileMode) (err error) {
 	}()
 
 	switch {
-	case path == "stdout": // reserved in zap
+	case path == Stdout:
 		fallthrough
 
-	case path == "stderr": // reserved in zap
+	case path == Stderr:
 		break
 
 	// Windows hack:  filepath.Abs will return false outside of Windows

--- a/config_test.go
+++ b/config_test.go
@@ -167,7 +167,7 @@ func (suite *ConfigSuite) TestDefaults() {
 	suite.False(zc.DisableStacktrace)
 	suite.Equal("json", zc.Encoding)
 	suite.Empty(zc.OutputPaths)
-	suite.Equal([]string{"stderr"}, zc.ErrorOutputPaths)
+	suite.Equal([]string{Stderr}, zc.ErrorOutputPaths)
 	suite.Nil(zc.Sampling)
 	suite.Empty(zc.InitialFields)
 
@@ -188,7 +188,7 @@ func (suite *ConfigSuite) TestCustom() {
 		},
 		Encoding:         "console",
 		OutputPaths:      []string{"/var/log/test/test.log"},
-		ErrorOutputPaths: []string{"stdout"},
+		ErrorOutputPaths: []string{Stdout},
 		InitialFields: map[string]interface{}{
 			"name":  "value",
 			"slice": []string{"1", "2"},
@@ -204,7 +204,7 @@ func (suite *ConfigSuite) TestCustom() {
 	suite.True(zc.DisableStacktrace)
 	suite.Equal("console", zc.Encoding)
 	suite.Equal([]string{"/var/log/test/test.log"}, zc.OutputPaths)
-	suite.Equal([]string{"stdout"}, zc.ErrorOutputPaths)
+	suite.Equal([]string{Stdout}, zc.ErrorOutputPaths)
 	suite.Equal(
 		zap.SamplingConfig{
 			Initial:    1,
@@ -239,8 +239,8 @@ func (suite *ConfigSuite) TestDevelopmentDefaults() {
 	suite.False(zc.DisableCaller)
 	suite.False(zc.DisableStacktrace)
 	suite.Equal("json", zc.Encoding)
-	suite.Equal([]string{"stdout"}, zc.OutputPaths)
-	suite.Equal([]string{"stderr"}, zc.ErrorOutputPaths)
+	suite.Equal([]string{Stdout}, zc.OutputPaths)
+	suite.Equal([]string{Stderr}, zc.ErrorOutputPaths)
 	suite.Nil(zc.Sampling)
 	suite.Empty(zc.InitialFields)
 
@@ -282,14 +282,14 @@ func (suite *ConfigSuite) TestBuildSimple() {
 func (suite *ConfigSuite) TestBuildWithPermissions() {
 	c := Config{
 		OutputPaths: []string{
-			"stdout",
-			"stderr",
+			Stdout,
+			Stderr,
 			filepath.Join(suite.logDirectory, "test.log"),
 			"file://" + filepath.Join(suite.logDirectory, "test-uri.log"),
 		},
 		ErrorOutputPaths: []string{
-			"stdout",
-			"stderr",
+			Stdout,
+			Stderr,
 			filepath.Join(suite.logDirectory, "test-error.log"),
 			"file://" + filepath.Join(suite.logDirectory, "test-error-uri.log"),
 		},

--- a/config_test.go
+++ b/config_test.go
@@ -4,44 +4,49 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-func assertZapcoreEncoderConfigDefaults(assert *assert.Assertions, zec zapcore.EncoderConfig) {
-	assert.Equal(DefaultMessageKey, zec.MessageKey)
-	assert.Equal(DefaultLevelKey, zec.LevelKey)
-	assert.Equal(DefaultTimeKey, zec.TimeKey)
-	assert.Equal(DefaultNameKey, zec.NameKey)
-	assert.Empty(zec.CallerKey)
-	assert.Empty(zec.FunctionKey)
-	assert.Empty(zec.StacktraceKey)
-	assert.NotNil(zec.EncodeLevel)
-	assert.NotNil(zec.EncodeTime)
-	assert.NotNil(zec.EncodeDuration)
-	assert.NotNil(zec.EncodeCaller)
-	assert.NotNil(zec.EncodeName)
+// ZapcoreSuite is an embeddable suite that contains common functionality
+// for the test suites involving configuration.
+type ZapcoreSuite struct {
+	suite.Suite
 }
 
-func testEncoderConfigDefaults(t *testing.T) {
+func (suite *ZapcoreSuite) assertEncoderConfigDefaults(zec zapcore.EncoderConfig) {
+	suite.Equal(DefaultMessageKey, zec.MessageKey)
+	suite.Equal(DefaultLevelKey, zec.LevelKey)
+	suite.Equal(DefaultTimeKey, zec.TimeKey)
+	suite.Equal(DefaultNameKey, zec.NameKey)
+	suite.Empty(zec.CallerKey)
+	suite.Empty(zec.FunctionKey)
+	suite.Empty(zec.StacktraceKey)
+	suite.NotNil(zec.EncodeLevel)
+	suite.NotNil(zec.EncodeTime)
+	suite.NotNil(zec.EncodeDuration)
+	suite.NotNil(zec.EncodeCaller)
+	suite.NotNil(zec.EncodeName)
+}
+
+type EncoderConfigSuite struct {
+	ZapcoreSuite
+}
+
+func (suite *EncoderConfigSuite) TestDefaults() {
 	var (
-		assert  = assert.New(t)
-		require = require.New(t)
-		ec      EncoderConfig
+		ec       EncoderConfig
+		zec, err = ec.NewZapcoreEncoderConfig()
 	)
 
-	zec, err := ec.NewZapcoreEncoderConfig()
-	require.NoError(err)
-	assertZapcoreEncoderConfigDefaults(assert, zec)
+	suite.Require().NoError(err)
+	suite.assertEncoderConfigDefaults(zec)
 }
 
-func testEncoderConfigCustom(t *testing.T) {
+func (suite *EncoderConfigSuite) TestCustom() {
 	var (
-		assert  = assert.New(t)
-		require = require.New(t)
-		ec      = EncoderConfig{
+		ec = EncoderConfig{
 			MessageKey:     "message_key",
 			LevelKey:       "level_key",
 			TimeKey:        "time_key",
@@ -58,121 +63,113 @@ func testEncoderConfigCustom(t *testing.T) {
 			LineEnding:       "foo",
 			ConsoleSeparator: "bar",
 		}
+
+		zec, err = ec.NewZapcoreEncoderConfig()
 	)
 
-	zec, err := ec.NewZapcoreEncoderConfig()
-	require.NoError(err)
+	suite.Require().NoError(err)
 
-	assert.Equal("message_key", zec.MessageKey)
-	assert.Equal("level_key", zec.LevelKey)
-	assert.Equal("time_key", zec.TimeKey)
-	assert.Equal("name_key", zec.NameKey)
-	assert.Equal("caller_key", zec.CallerKey)
-	assert.Equal("function_key", zec.FunctionKey)
-	assert.Equal("stacktrace_key", zec.StacktraceKey)
-	assert.NotNil(zec.EncodeLevel)
-	assert.NotNil(zec.EncodeTime)
-	assert.NotNil(zec.EncodeDuration)
-	assert.NotNil(zec.EncodeCaller)
-	assert.NotNil(zec.EncodeName)
+	suite.Equal("message_key", zec.MessageKey)
+	suite.Equal("level_key", zec.LevelKey)
+	suite.Equal("time_key", zec.TimeKey)
+	suite.Equal("name_key", zec.NameKey)
+	suite.Equal("caller_key", zec.CallerKey)
+	suite.Equal("function_key", zec.FunctionKey)
+	suite.Equal("stacktrace_key", zec.StacktraceKey)
+	suite.NotNil(zec.EncodeLevel)
+	suite.NotNil(zec.EncodeTime)
+	suite.NotNil(zec.EncodeDuration)
+	suite.NotNil(zec.EncodeCaller)
+	suite.NotNil(zec.EncodeName)
 
-	assert.Equal("foo", zec.LineEnding)
-	assert.Equal("bar", zec.ConsoleSeparator)
+	suite.Equal("foo", zec.LineEnding)
+	suite.Equal("bar", zec.ConsoleSeparator)
 }
 
-func testEncoderConfigDisableDefaultKeys(t *testing.T) {
+func (suite *EncoderConfigSuite) TestDisableDefaultKeys() {
 	var (
-		assert  = assert.New(t)
-		require = require.New(t)
-		ec      = EncoderConfig{
+		ec = EncoderConfig{
 			DisableDefaultKeys: true,
 		}
+
+		zec, err = ec.NewZapcoreEncoderConfig()
 	)
 
-	zec, err := ec.NewZapcoreEncoderConfig()
-	require.NoError(err)
+	suite.Require().NoError(err)
 
-	assert.Empty(zec.MessageKey)
-	assert.Empty(zec.LevelKey)
-	assert.Empty(zec.TimeKey)
-	assert.Empty(zec.NameKey)
-	assert.Empty(zec.CallerKey)
-	assert.Empty(zec.FunctionKey)
-	assert.Empty(zec.StacktraceKey)
-	assert.NotNil(zec.EncodeLevel)
-	assert.NotNil(zec.EncodeTime)
-	assert.NotNil(zec.EncodeDuration)
-	assert.NotNil(zec.EncodeCaller)
-	assert.NotNil(zec.EncodeName)
+	suite.Empty(zec.MessageKey)
+	suite.Empty(zec.LevelKey)
+	suite.Empty(zec.TimeKey)
+	suite.Empty(zec.NameKey)
+	suite.Empty(zec.CallerKey)
+	suite.Empty(zec.FunctionKey)
+	suite.Empty(zec.StacktraceKey)
+	suite.NotNil(zec.EncodeLevel)
+	suite.NotNil(zec.EncodeTime)
+	suite.NotNil(zec.EncodeDuration)
+	suite.NotNil(zec.EncodeCaller)
+	suite.NotNil(zec.EncodeName)
 }
 
 func TestEncoderConfig(t *testing.T) {
-	t.Run("Defaults", testEncoderConfigDefaults)
-	t.Run("Custom", testEncoderConfigCustom)
-	t.Run("DisableDefaultKeys", testEncoderConfigDisableDefaultKeys)
+	suite.Run(t, new(EncoderConfigSuite))
 }
 
-func testConfigNewZapConfigDefaults(t *testing.T) {
-	var (
-		assert  = assert.New(t)
-		require = require.New(t)
+type ConfigSuite struct {
+	ZapcoreSuite
+}
 
-		c Config
-	)
+func (suite *ConfigSuite) TestDefaults() {
+	var c Config
 
 	zc, err := c.NewZapConfig()
-	require.NoError(err)
+	suite.Require().NoError(err)
 
-	assert.Equal(zapcore.InfoLevel, zc.Level.Level())
-	assert.False(zc.Development)
-	assert.False(zc.DisableCaller)
-	assert.False(zc.DisableStacktrace)
-	assert.Equal("json", zc.Encoding)
-	assert.Empty(zc.OutputPaths)
-	assert.Equal([]string{"stderr"}, zc.ErrorOutputPaths)
-	assert.Nil(zc.Sampling)
-	assert.Empty(zc.InitialFields)
+	suite.Equal(zapcore.InfoLevel, zc.Level.Level())
+	suite.False(zc.Development)
+	suite.False(zc.DisableCaller)
+	suite.False(zc.DisableStacktrace)
+	suite.Equal("json", zc.Encoding)
+	suite.Empty(zc.OutputPaths)
+	suite.Equal([]string{"stderr"}, zc.ErrorOutputPaths)
+	suite.Nil(zc.Sampling)
+	suite.Empty(zc.InitialFields)
 
 	zec, err := c.EncoderConfig.NewZapcoreEncoderConfig()
-	require.NoError(err)
-	assertZapcoreEncoderConfigDefaults(assert, zec)
+	suite.Require().NoError(err)
+	suite.assertEncoderConfigDefaults(zec)
 }
 
-func testConfigNewZapConfigCustom(t *testing.T) {
-	var (
-		assert  = assert.New(t)
-		require = require.New(t)
-
-		c = Config{
-			Level:             "debug",
-			Development:       true,
-			DisableCaller:     true,
-			DisableStacktrace: true,
-			Sampling: &zap.SamplingConfig{
-				Initial:    1,
-				Thereafter: 10,
-			},
-			Encoding:         "console",
-			OutputPaths:      []string{"/var/log/test/test.log"},
-			ErrorOutputPaths: []string{"stdout"},
-			InitialFields: map[string]interface{}{
-				"name":  "value",
-				"slice": []string{"1", "2"},
-			},
-		}
-	)
+func (suite *ConfigSuite) TestCustom() {
+	c := Config{
+		Level:             "debug",
+		Development:       true,
+		DisableCaller:     true,
+		DisableStacktrace: true,
+		Sampling: &zap.SamplingConfig{
+			Initial:    1,
+			Thereafter: 10,
+		},
+		Encoding:         "console",
+		OutputPaths:      []string{"/var/log/test/test.log"},
+		ErrorOutputPaths: []string{"stdout"},
+		InitialFields: map[string]interface{}{
+			"name":  "value",
+			"slice": []string{"1", "2"},
+		},
+	}
 
 	zc, err := c.NewZapConfig()
-	require.NoError(err)
+	suite.Require().NoError(err)
 
-	assert.Equal(zapcore.DebugLevel, zc.Level.Level())
-	assert.True(zc.Development)
-	assert.True(zc.DisableCaller)
-	assert.True(zc.DisableStacktrace)
-	assert.Equal("console", zc.Encoding)
-	assert.Equal([]string{"/var/log/test/test.log"}, zc.OutputPaths)
-	assert.Equal([]string{"stdout"}, zc.ErrorOutputPaths)
-	assert.Equal(
+	suite.Equal(zapcore.DebugLevel, zc.Level.Level())
+	suite.True(zc.Development)
+	suite.True(zc.DisableCaller)
+	suite.True(zc.DisableStacktrace)
+	suite.Equal("console", zc.Encoding)
+	suite.Equal([]string{"/var/log/test/test.log"}, zc.OutputPaths)
+	suite.Equal([]string{"stdout"}, zc.ErrorOutputPaths)
+	suite.Equal(
 		zap.SamplingConfig{
 			Initial:    1,
 			Thereafter: 10,
@@ -180,7 +177,7 @@ func testConfigNewZapConfigCustom(t *testing.T) {
 		*zc.Sampling,
 	)
 
-	assert.Equal(
+	suite.Equal(
 		map[string]interface{}{
 			"name":  "value",
 			"slice": []string{"1", "2"},
@@ -189,49 +186,35 @@ func testConfigNewZapConfigCustom(t *testing.T) {
 	)
 
 	zec, err := c.EncoderConfig.NewZapcoreEncoderConfig()
-	require.NoError(err)
-	assertZapcoreEncoderConfigDefaults(assert, zec)
+	suite.Require().NoError(err)
+	suite.assertEncoderConfigDefaults(zec)
 }
 
-func testConfigNewZapConfigDevelopmentDefaults(t *testing.T) {
-	var (
-		assert  = assert.New(t)
-		require = require.New(t)
-
-		c = Config{
-			Development: true,
-		}
-	)
+func (suite *ConfigSuite) TestDevelopmentDefaults() {
+	c := Config{
+		Development: true,
+	}
 
 	zc, err := c.NewZapConfig()
-	require.NoError(err)
+	suite.Require().NoError(err)
 
-	assert.Equal(zapcore.InfoLevel, zc.Level.Level())
-	assert.True(zc.Development)
-	assert.False(zc.DisableCaller)
-	assert.False(zc.DisableStacktrace)
-	assert.Equal("json", zc.Encoding)
-	assert.Equal([]string{"stdout"}, zc.OutputPaths)
-	assert.Equal([]string{"stderr"}, zc.ErrorOutputPaths)
-	assert.Nil(zc.Sampling)
-	assert.Empty(zc.InitialFields)
+	suite.Equal(zapcore.InfoLevel, zc.Level.Level())
+	suite.True(zc.Development)
+	suite.False(zc.DisableCaller)
+	suite.False(zc.DisableStacktrace)
+	suite.Equal("json", zc.Encoding)
+	suite.Equal([]string{"stdout"}, zc.OutputPaths)
+	suite.Equal([]string{"stderr"}, zc.ErrorOutputPaths)
+	suite.Nil(zc.Sampling)
+	suite.Empty(zc.InitialFields)
 
 	zec, err := c.EncoderConfig.NewZapcoreEncoderConfig()
-	require.NoError(err)
-	assertZapcoreEncoderConfigDefaults(assert, zec)
+	suite.Require().NoError(err)
+	suite.assertEncoderConfigDefaults(zec)
 }
 
-func testConfigNewZapConfig(t *testing.T) {
-	t.Run("Defaults", testConfigNewZapConfigDefaults)
-	t.Run("Custom", testConfigNewZapConfigCustom)
-	t.Run("DevelopmentDefaults", testConfigNewZapConfigDevelopmentDefaults)
-}
-
-func testConfigBuildSimple(t *testing.T) {
+func (suite *ConfigSuite) TestBuildSimple() {
 	var (
-		assert  = assert.New(t)
-		require = require.New(t)
-
 		buffer bytes.Buffer
 
 		c = Config{
@@ -242,7 +225,7 @@ func testConfigBuildSimple(t *testing.T) {
 	// create an encoder config to replace the one created by the zap package
 	// so that we can run assertions
 	zec, err := EncoderConfig{}.NewZapcoreEncoderConfig()
-	require.NoError(err)
+	suite.Require().NoError(err)
 
 	l, err := c.Build(
 		zap.WrapCore(func(zapcore.Core) zapcore.Core {
@@ -254,17 +237,12 @@ func testConfigBuildSimple(t *testing.T) {
 		}),
 	)
 
-	require.NoError(err)
-	require.NotNil(l)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(l)
 	l.Info("test message")
-	assert.Greater(buffer.Len(), 0)
-}
-
-func testConfigBuild(t *testing.T) {
-	t.Run("Simple", testConfigBuildSimple)
+	suite.Greater(buffer.Len(), 0)
 }
 
 func TestConfig(t *testing.T) {
-	t.Run("NewZapConfig", testConfigNewZapConfig)
-	t.Run("Build", testConfigBuild)
+	suite.Run(t, new(ConfigSuite))
 }

--- a/permissions.go
+++ b/permissions.go
@@ -1,0 +1,47 @@
+package sallust
+
+import (
+	"errors"
+	"io/fs"
+)
+
+var (
+	// ErrInvalidPermissions is returned by ParsePermissions to indicate a bad permissions value.
+	ErrInvalidPermissions = errors.New("Invalid permissions")
+)
+
+func accumulate(v byte, factor int, perms *fs.FileMode) (ok bool) {
+	if ok = v >= '0' && v <= '7'; ok {
+		*perms += (fs.FileMode(int(v-'0') * factor))
+	}
+
+	return
+}
+
+// ParsePermissions parses a nix-style file permissions value.  The value must be a 3-digit
+// octal integer with an optional leading zero (0).  The empty string is considered to be
+// an invalid permissions value.
+func ParsePermissions(v string) (perms fs.FileMode, err error) {
+	switch {
+	case len(v) < 3:
+		fallthrough
+
+	case len(v) > 4:
+		fallthrough
+
+	// if 4 characters, the first character must be a zero (0)
+	case len(v) == 4 && v[0] != '0':
+		err = ErrInvalidPermissions
+
+	case !accumulate(v[len(v)-1], 1, &perms):
+		err = ErrInvalidPermissions
+
+	case !accumulate(v[len(v)-2], 8, &perms):
+		err = ErrInvalidPermissions
+
+	case !accumulate(v[len(v)-3], 64, &perms):
+		err = ErrInvalidPermissions
+	}
+
+	return
+}

--- a/permissions.go
+++ b/permissions.go
@@ -19,10 +19,13 @@ func accumulate(v byte, factor int, perms *fs.FileMode) (ok bool) {
 }
 
 // ParsePermissions parses a nix-style file permissions value.  The value must be a 3-digit
-// octal integer with an optional leading zero (0).  The empty string is considered to be
-// an invalid permissions value.
+// octal integer with an optional leading zero (0).  The empty string is considered to be 000.
 func ParsePermissions(v string) (perms fs.FileMode, err error) {
 	switch {
+	// allows for an unset configuration value, which means just take the underlying defaults
+	case len(v) == 0:
+		return
+
 	case len(v) < 3:
 		fallthrough
 

--- a/permissions_test.go
+++ b/permissions_test.go
@@ -1,0 +1,63 @@
+package sallust
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ParsePermissionsTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ParsePermissionsTestSuite) TestValid() {
+	testCases := []struct {
+		value    string
+		expected fs.FileMode
+	}{
+		{value: "644", expected: 0644},
+		{value: "0644", expected: 0644},
+		{value: "666", expected: 0666},
+		{value: "0666", expected: 0666},
+		{value: "600", expected: 0600},
+		{value: "0600", expected: 0600},
+		{value: "000", expected: 0000},
+		{value: "0000", expected: 0000},
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase.value, func() {
+			actual, err := ParsePermissions(testCase.value)
+			suite.Require().NoError(err)
+			suite.Equal(testCase.expected, actual)
+		})
+	}
+}
+
+func (suite *ParsePermissionsTestSuite) TestInvalid() {
+	testCases := []string{
+		"",
+		"0",
+		"463213",
+		"900",
+		"0900",
+		"090",
+		"0090",
+		"009",
+		"0009",
+		"x000",
+		"this is definitely invalid",
+	}
+
+	for _, testCase := range testCases {
+		suite.Run(testCase, func() {
+			_, err := ParsePermissions(testCase)
+			suite.ErrorIs(err, ErrInvalidPermissions)
+		})
+	}
+}
+
+func TestParsePermissions(t *testing.T) {
+	suite.Run(t, new(ParsePermissionsTestSuite))
+}

--- a/permissions_test.go
+++ b/permissions_test.go
@@ -16,6 +16,7 @@ func (suite *ParsePermissionsTestSuite) TestValid() {
 		value    string
 		expected fs.FileMode
 	}{
+		{value: "", expected: 0},
 		{value: "644", expected: 0644},
 		{value: "0644", expected: 0644},
 		{value: "666", expected: 0666},
@@ -37,7 +38,6 @@ func (suite *ParsePermissionsTestSuite) TestValid() {
 
 func (suite *ParsePermissionsTestSuite) TestInvalid() {
 	testCases := []string{
-		"",
 		"0",
 		"463213",
 		"900",


### PR DESCRIPTION
This allows you to put a `permissions` field in the server configuration file that is the Unix-style permissions for all log files created by `zap` and `lumberjack`.

This addresses https://github.com/xmidt-org/sallust/issues/51
